### PR TITLE
Disable NSMenu autoenablesItems

### DIFF
--- a/src/Plugins/SubMenu/SubMenu/HITPSubMenu.m
+++ b/src/Plugins/SubMenu/SubMenu/HITPSubMenu.m
@@ -61,6 +61,7 @@ typedef NS_ENUM(NSInteger, HITPSubMenuSortScenario) {
     menuItem.target = nil;
     
     NSMenu *menu = [[NSMenu alloc] init];
+    menu.autoenablesItems = FALSE;
     menu.delegate = self;
     self.subPluginInstances = [NSMutableArray new];
     self.observedSubPluginInstances = [NSMutableArray new];


### PR DESCRIPTION
Set menu.autoenablesItems to false to allow for disabling ScriptedItem menu items. In the current release, 'setEnabled NO' has no effect.